### PR TITLE
Fix webhook error missing updater

### DIFF
--- a/.github/workflows/medicine-bot-ci.yml
+++ b/.github/workflows/medicine-bot-ci.yml
@@ -2,9 +2,7 @@ name: Medicine Bot CI/CD
 
 on:
   push:
-    branches: ["**"]
   pull_request:
-    branches: ["**"]
   workflow_dispatch:
 
 env:

--- a/main.py
+++ b/main.py
@@ -53,10 +53,7 @@ class MedicineReminderBot:
             builder = Application.builder()
             builder.token(config.BOT_TOKEN)
             
-            # Configure for webhook if in production
-            if config.is_production():
-                builder.updater(None)  # Disable polling for webhook mode
-            
+            # Note: Keep Updater enabled to support run_webhook
             self.application = builder.build()
             
             # Set up bot reference for scheduler


### PR DESCRIPTION
Fix webhook deployment error by ensuring Updater is always present and simplify CI triggers.

The `RuntimeError: Application.run_webhook is only available if the application has an Updater.` occurred because the `Updater` was explicitly disabled in production environments. This change ensures the `Updater` is always built, which is required for `run_webhook` to function correctly in `python-telegram-bot` v22+. Additionally, CI triggers were simplified to run on all pushes and pull requests.

---
<a href="https://cursor.com/background-agent?bcId=bc-517b586c-6631-4424-9883-eb1d46ae637e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-517b586c-6631-4424-9883-eb1d46ae637e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

