### PR TITLE
Fix medicine handler attribute error

### DIFF
--- a/handlers/medicine_handler.py
+++ b/handlers/medicine_handler.py
@@ -677,6 +677,54 @@ class MedicineHandler:
             )
             return ConversationHandler.END
 
+    async def edit_medicine(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
+        """Handle request to edit medicine details (placeholder)."""
+        try:
+            query = update.callback_query
+            await query.answer()
+            
+            # Expect callback data like: medicine_edit_<id>
+            parts = query.data.split("_")
+            medicine_id = int(parts[2]) if len(parts) > 2 else None
+            if not medicine_id:
+                await query.edit_message_text(
+                    f"{config.EMOJIS['error']} שגיאה: לא נמצא מזהה התרופה"
+                )
+                return ConversationHandler.END
+            
+            medicine = await DatabaseManager.get_medicine_by_id(medicine_id)
+            if not medicine:
+                await query.edit_message_text(
+                    f"{config.EMOJIS['error']} התרופה לא נמצאה"
+                )
+                return ConversationHandler.END
+            
+            message = f"""
+{config.EMOJIS['settings']} <b>עריכת תרופה</b>
+
+פיצ׳ר עריכת פרטי התרופה יתווסף בקרוב.
+בינתיים ניתן:
+- לעדכן מלאי
+- לצפות בפרטי התרופה
+            """
+            
+            await query.edit_message_text(
+                message,
+                parse_mode='HTML',
+                reply_markup=get_medicine_detail_keyboard(medicine_id)
+            )
+            
+            return ConversationHandler.END
+        except Exception as e:
+            logger.error(f"Error handling edit medicine: {e}")
+            try:
+                await update.callback_query.edit_message_text(
+                    f"{config.EMOJIS['error']} שגיאה בעריכת התרופה"
+                )
+            except Exception:
+                pass
+            return ConversationHandler.END
+
 
 # Global instance
 medicine_handler = MedicineHandler()


### PR DESCRIPTION
Add a placeholder `edit_medicine` method to `MedicineHandler` to resolve an `AttributeError` during bot initialization.

The `AttributeError` occurred because `CallbackQueryHandler` was configured to call `self.edit_medicine`, but the method did not exist in the `MedicineHandler` class, preventing the bot from starting. This change adds a minimal asynchronous method to allow the bot to initialize and provides a temporary message when the "edit" button is pressed.

---
<a href="https://cursor.com/background-agent?bcId=bc-28a2bfcf-e7b5-44ea-938d-9964cadf62ab">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-28a2bfcf-e7b5-44ea-938d-9964cadf62ab">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

