### PR TITLE
Fix caregiver menu buttons and help button

### DIFF
--- a/handlers/caregiver_handler.py
+++ b/handlers/caregiver_handler.py
@@ -132,7 +132,8 @@ class CaregiverHandler:
             # Initialize caregiver data
             self.user_caregiver_data[user_id] = {
                 'user_id': user.id,
-                'step': 'name'
+                'step': 'name',
+                'caregiver_telegram_id': None
             }
             
             message = f"""

--- a/main.py
+++ b/main.py
@@ -166,8 +166,7 @@ class MedicineReminderBot:
         """Handle /help command"""
         try:
             await update.message.reply_text(
-                config.HELP_MESSAGE,
-                parse_mode='Markdown'
+                config.HELP_MESSAGE
             )
         except Exception as e:
             logger.error(f"Error in help command: {e}")


### PR DESCRIPTION
Fixes non-functional "Add Caregiver" permission buttons and the "Help" button.

The "Add Caregiver" permission buttons failed because `caregiver_telegram_id` was not initialized, causing a KeyError when saving permissions if the Telegram ID input step was skipped. The "Help" button failed due to Telegram Markdown parsing errors in the help text.

---
<a href="https://cursor.com/background-agent?bcId=bc-334977f0-ad10-49ff-bbc5-e83f3c701f45">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-334977f0-ad10-49ff-bbc5-e83f3c701f45">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

