### PR TITLE
Revert recent bot changes

### DIFF
--- a/config.py
+++ b/config.py
@@ -146,6 +146,8 @@ class Config:
         "back": "⬅️",
         "next": "➡️",
         "doctor": "👨‍⚕️",
+        "symptoms": "🤒",
+        "clock": "🕒",
     }
 
     # Backward-compat alias for occasional typos


### PR DESCRIPTION
Add missing `symptoms` and `clock` emoji keys to fix `KeyError` in `/start` command.

---
<a href="https://cursor.com/background-agent?bcId=bc-cdb5f105-58f1-4bf2-aa48-59f9153d7129">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cdb5f105-58f1-4bf2-aa48-59f9153d7129">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

