### PR TITLE
Fix caregiver buttons and add copy message

### DIFF
--- a/database.py
+++ b/database.py
@@ -510,6 +510,17 @@ class DatabaseManager:
             return True
 
     @staticmethod
+    async def delete_caregiver(caregiver_id: int) -> bool:
+        """Permanently delete a caregiver by id (SQL backend)."""
+        async with async_session() as session:
+            caregiver = await session.get(Caregiver, caregiver_id)
+            if not caregiver:
+                return False
+            await session.delete(caregiver)
+            await session.commit()
+            return True
+
+    @staticmethod
     async def get_all_active_users() -> List[User]:
         """Return all active users"""
         async with async_session() as session:
@@ -1794,6 +1805,13 @@ class DatabaseManagerMongo:
         cg.is_active = d.get("is_active", True)
         cg.created_at = d.get("created_at") or datetime.utcnow()
         return cg
+
+    @staticmethod
+    async def delete_caregiver(caregiver_id: int) -> bool:
+        """Permanently delete a caregiver by id (Mongo backend)."""
+        await _init_mongo()
+        res = await _mongo_db.caregivers.delete_one({"_id": int(caregiver_id)})
+        return res.deleted_count > 0
 
     @staticmethod
     async def create_invite(user_id: int, caregiver_name: Optional[str] = None, ttl_hours: int = 72) -> "Invite":

--- a/handlers/caregiver_handler.py
+++ b/handlers/caregiver_handler.py
@@ -91,6 +91,7 @@ class CaregiverHandler:
             # Handle only specific caregiver actions here; let conversation handle add/manage/edit entries
             CallbackQueryHandler(self.handle_caregiver_actions, pattern=r"^caregiver_(invite|send_report|copy_inv_msg_.*)$"),
             CallbackQueryHandler(self.confirm_remove_caregiver, pattern=r"^remove_caregiver_"),
+            CallbackQueryHandler(self.execute_remove_caregiver, pattern=r"^confirm_remove_caregiver_"),
             CallbackQueryHandler(self.toggle_caregiver_status, pattern=r"^toggle_caregiver_"),
         ]
 
@@ -606,9 +607,11 @@ class CaregiverHandler:
                     f"כדי להצטרף, לחצו על הקישור והאשרו: {deep_link}"
                 ).strip()
                 msg = (
-                    f"{config.EMOJIS['caregiver']} יצירת הזמנה למטפל\n\n"
+                    f"{config.EMOJIS['caregiver']} <b>יצירת הזמנה למטפל</b>\n\n"
                     f"מטרת הפונקציה: לשלוח למטפל/ת שלך קישור הצטרפות פשוט, כדי שיוכלו לקבל ממך דוחות מעקב.\n\n"
-                    f"לחצו על הכפתור כדי לקבל הודעה מוכנה להעברה למטפל/ת.\n"
+                    f"לחצו על הכפתור כדי לקבל הודעה מוכנה להעברה למטפל/ת.\n\n"
+                    f"להעתקה ושליחה למטפל/ת:\n"
+                    f"<pre>{caregiver_msg}</pre>"
                 )
                 kb = [
                     [InlineKeyboardButton("📋 העתק הודעה למטפל", callback_data=f"copy_inv_msg_{inv.code}")],
@@ -631,8 +634,8 @@ class CaregiverHandler:
                         f"להצטרפות כמטפל/ת שלי, פשוט לחצו והאשרו: {link}"
                     ).strip()
                 await query.answer(text="✔️ הודעה מוכנה להעתקה נשלחה בצ׳אט", show_alert=False)
-                # Send the copyable message as a new message the user can forward
-                await context.bot.send_message(chat_id=query.message.chat_id, text=text)
+                # Send the copyable message as a new message the user can forward (code-style block)
+                await context.bot.send_message(chat_id=query.message.chat_id, text=f"<pre>{text}</pre>", parse_mode="HTML")
                 return
             if data == "caregiver_send_report":
                 # Send latest weekly report to all active caregivers with Telegram ID
@@ -702,13 +705,45 @@ class CaregiverHandler:
             await update.callback_query.edit_message_text(config.ERROR_MESSAGES["general"])
 
     async def confirm_remove_caregiver(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
-        """Confirm caregiver removal (placeholder)."""
+        """Confirm caregiver removal with a yes/no prompt."""
         try:
             query = update.callback_query
             await query.answer()
-            await query.edit_message_text(f"{config.EMOJIS['warning']} הסרת מטפל תיתמך בהמשך")
+            data = query.data
+            caregiver_id = int(data.split("_")[-1])
+            caregiver = await DatabaseManager.get_caregiver_by_id(caregiver_id)
+            if not caregiver:
+                await query.edit_message_text(f"{config.EMOJIS['error']} מטפל לא נמצא")
+                return
+            msg = (
+                f"{config.EMOJIS['warning']} האם להסיר לצמיתות את המטפל:\n\n"
+                f"<b>{caregiver.caregiver_name}</b>?\n\n"
+                f"הפעולה אינה ניתנת לשחזור."
+            )
+            kb = [
+                [InlineKeyboardButton("כן, הסר", callback_data=f"confirm_remove_caregiver_{caregiver_id}")],
+                [InlineKeyboardButton(f"{config.EMOJIS['back']} חזור", callback_data=f"caregiver_edit_{caregiver_id}")],
+            ]
+            await query.edit_message_text(msg, parse_mode="HTML", reply_markup=InlineKeyboardMarkup(kb))
         except Exception as e:
             logger.error(f"Error in confirm_remove_caregiver: {e}")
+            await update.callback_query.edit_message_text(config.ERROR_MESSAGES["general"])
+
+    async def execute_remove_caregiver(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
+        """Execute caregiver deletion and refresh the caregivers list."""
+        try:
+            query = update.callback_query
+            await query.answer()
+            data = query.data
+            caregiver_id = int(data.split("_")[-1])
+            ok = await DatabaseManager.delete_caregiver(caregiver_id)
+            if ok:
+                # Refresh the caregivers list
+                await self.view_caregivers(update, context)
+            else:
+                await query.edit_message_text(f"{config.EMOJIS['error']} לא נמצא מטפל להסרה")
+        except Exception as e:
+            logger.error(f"Error in execute_remove_caregiver: {e}")
             await update.callback_query.edit_message_text(config.ERROR_MESSAGES["general"])
 
     async def toggle_caregiver_status(self, update: Update, context: ContextTypes.DEFAULT_TYPE):


### PR DESCRIPTION
Fix 'Remove caregiver' and 'Copy message to caregiver' buttons and add a copyable message preview.

The "Remove caregiver" button now includes a confirmation step and performs deletion in both SQL and Mongo backends. The "Copy message to caregiver" button now sends the invite message formatted as a code block with a copy button, as requested by the user, and a preview of this message is also shown on the invite screen.

---
<a href="https://cursor.com/background-agent?bcId=bc-cfeed26b-d0c1-4a15-8aef-fdfde2529620">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cfeed26b-d0c1-4a15-8aef-fdfde2529620">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

