### PR TITLE
Fix deployment port binding issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,9 @@
    ```
    BOT_TOKEN=your_bot_token_here
    BOT_USERNAME=your_bot_username
-   WEBHOOK_URL=https://your-app-name.onrender.com
+   # Prefer setting RENDER_EXTERNAL_URL automatically provided by Render.
+   # If not available, set WEBHOOK_URL explicitly:
+   # WEBHOOK_URL=https://your-app-name.onrender.com
    DEBUG=False
    LOG_LEVEL=INFO
    DATABASE_URL=sqlite+aiosqlite:///./medicine_bot.db

--- a/config.py
+++ b/config.py
@@ -161,8 +161,8 @@ class Config:
         if not cls.BOT_TOKEN:
             errors.append("BOT_TOKEN is required")
 
-        if not cls.WEBHOOK_URL and os.getenv("RENDER"):
-            errors.append("WEBHOOK_URL is required for Render deployment")
+        if os.getenv("RENDER") and not (cls.WEBHOOK_URL or os.getenv("RENDER_EXTERNAL_URL")):
+            errors.append("WEBHOOK_URL or RENDER_EXTERNAL_URL is required for Render deployment")
 
         if cls.WEBHOOK_PORT < 1 or cls.WEBHOOK_PORT > 65535:
             errors.append("WEBHOOK_PORT must be between 1 and 65535")
@@ -186,8 +186,9 @@ class Config:
     @classmethod
     def get_webhook_url(cls) -> str:
         """Get full webhook URL"""
-        if cls.WEBHOOK_URL:
-            return f"{cls.WEBHOOK_URL.rstrip('/')}{cls.WEBHOOK_PATH}"
+        base_url = cls.WEBHOOK_URL or os.getenv("RENDER_EXTERNAL_URL", "")
+        if base_url:
+            return f"{base_url.rstrip('/')}{cls.WEBHOOK_PATH}"
         return ""
 
 

--- a/main.py
+++ b/main.py
@@ -51,10 +51,62 @@ class MedicineReminderBot:
 
     def run_polling(self):
         """Build (if needed) and run the bot with polling. Blocks until interrupted."""
+        # Lazy imports to avoid side effects at import time
+        from scheduler import medicine_scheduler
+
         app = self.app or self.build()
+
+        async def _on_startup(_: Any):
+            await medicine_scheduler.start()
+
+        async def _on_shutdown(_: Any):
+            await medicine_scheduler.stop()
+
+        app.post_init = _on_startup
+        app.post_shutdown = _on_shutdown
+
         app.run_polling()
+
+    def run_webhook(self):
+        """Run the bot using a built-in webhook webserver (for Render)."""
+        # Lazy imports to avoid side effects at import time
+        import os
+        from config import config
+        from scheduler import medicine_scheduler
+
+        app = self.app or self.build()
+
+        async def _on_startup(_: Any):
+            await medicine_scheduler.start()
+
+        async def _on_shutdown(_: Any):
+            await medicine_scheduler.stop()
+
+        app.post_init = _on_startup
+        app.post_shutdown = _on_shutdown
+
+        webhook_url = config.get_webhook_url()
+        url_path = config.WEBHOOK_PATH.lstrip("/")
+        listen_host = "0.0.0.0"
+        port = int(os.getenv("PORT", str(config.WEBHOOK_PORT)))
+
+        app.run_webhook(
+            listen=listen_host,
+            port=port,
+            url_path=url_path,
+            webhook_url=(webhook_url or None),
+            drop_pending_updates=True,
+        )
 
 
 if __name__ == "__main__":
-    # Run using polling when executed directly
-    MedicineReminderBot().run_polling()
+    # Prefer webhook mode on Render (binds to PORT), fallback to polling locally
+    import os
+    from config import config
+
+    bot = MedicineReminderBot()
+
+    if os.getenv("RENDER") or config.get_webhook_url():
+        bot.run_webhook()
+    else:
+        bot.run_polling()


### PR DESCRIPTION
Add webhook server support for Render deployments to resolve port binding issues.

The deployment on Render was failing because the application was not binding to any port, leading to a "Port scan timeout". This PR introduces a webhook server mode that listens on the `PORT` environment variable (as required by Render) and automatically configures the webhook URL using `RENDER_EXTERNAL_URL` if available, ensuring the application properly exposes a service.

---
<a href="https://cursor.com/background-agent?bcId=bc-df425fee-dd01-408f-82fe-9760c3bd79c1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-df425fee-dd01-408f-82fe-9760c3bd79c1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

