### PR TITLE
Deploy python telegram bot

### DIFF
--- a/handlers/caregiver_handler.py
+++ b/handlers/caregiver_handler.py
@@ -80,7 +80,7 @@ class CaregiverHandler:
                 CommandHandler("cancel", self.cancel_operation),
                 CallbackQueryHandler(self.cancel_operation, pattern="^cancel$"),
             ],
-            per_message=False,
+            per_message=True,
         )
 
     def get_handlers(self) -> List:

--- a/handlers/medicine_handler.py
+++ b/handlers/medicine_handler.py
@@ -73,7 +73,7 @@ class MedicineHandler:
                 CallbackQueryHandler(self.cancel_operation, pattern="^cancel$"),
                 CallbackQueryHandler(self.cancel_operation, pattern="^time_cancel$"),
             ],
-            per_message=False,
+            per_message=True,
         )
 
     async def start_add_medicine(self, update: Update, context: ContextTypes.DEFAULT_TYPE):

--- a/handlers/reports_handler.py
+++ b/handlers/reports_handler.py
@@ -76,7 +76,7 @@ class ReportsHandler:
                 CommandHandler("cancel", self.cancel_report),
                 CallbackQueryHandler(self.cancel_report, pattern="^cancel$"),
             ],
-            per_message=False,
+            per_message=True,
         )
 
     def get_handlers(self) -> List:


### PR DESCRIPTION
Update `ConversationHandler` to set `per_message=True` to resolve `PTBUserWarning` for `CallbackQueryHandler`.

The `PTBUserWarning` indicated that `CallbackQueryHandler` instances within `ConversationHandler` were not being tracked for every message when `per_message` was set to `False`. Setting `per_message=True` ensures proper tracking and eliminates the warning, aligning with the recommended usage for such handlers.

---
<a href="https://cursor.com/background-agent?bcId=bc-538eee81-2bea-4f5d-b357-7e7592aeccc5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-538eee81-2bea-4f5d-b357-7e7592aeccc5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

