### PR TITLE
Fix per message warnings in handlers

### DIFF
--- a/handlers/caregiver_handler.py
+++ b/handlers/caregiver_handler.py
@@ -80,7 +80,7 @@ class CaregiverHandler:
                 CommandHandler("cancel", self.cancel_operation),
                 CallbackQueryHandler(self.cancel_operation, pattern="^cancel$"),
             ],
-            per_message=True,
+            per_message=False,
         )
 
     def get_handlers(self) -> List:

--- a/handlers/medicine_handler.py
+++ b/handlers/medicine_handler.py
@@ -73,7 +73,7 @@ class MedicineHandler:
                 CallbackQueryHandler(self.cancel_operation, pattern="^cancel$"),
                 CallbackQueryHandler(self.cancel_operation, pattern="^time_cancel$"),
             ],
-            per_message=True,
+            per_message=False,
         )
 
     async def start_add_medicine(self, update: Update, context: ContextTypes.DEFAULT_TYPE):

--- a/handlers/reports_handler.py
+++ b/handlers/reports_handler.py
@@ -76,7 +76,7 @@ class ReportsHandler:
                 CommandHandler("cancel", self.cancel_report),
                 CallbackQueryHandler(self.cancel_report, pattern="^cancel$"),
             ],
-            per_message=True,
+            per_message=False,
         )
 
     def get_handlers(self) -> List:


### PR DESCRIPTION
Disable `per_message` in ConversationHandlers to resolve PTB warnings and fix stuck menu.

---
<a href="https://cursor.com/background-agent?bcId=bc-a36fdb51-ea9f-4447-b6b2-4b0dfd2a49e9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a36fdb51-ea9f-4447-b6b2-4b0dfd2a49e9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

