### PR TITLE
Fix database syntax error in deployment

### DIFF
--- a/database.py
+++ b/database.py
@@ -86,7 +86,7 @@ class DoseLog(Base):
 
     __tablename__ = "dose_logs"
 
-    id: Mapped[int] = mapped_column(Integer, primary key=True)
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
     medicine_id: Mapped[int] = mapped_column(Integer, ForeignKey("medicines.id"))
     scheduled_time: Mapped[datetime] = mapped_column(DateTime)
     taken_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)


### PR DESCRIPTION
Fix `SyntaxError` in `database.py` by correcting `primary key` to `primary_key`.

The deployment failed due to a `SyntaxError` in `database.py` where `primary key=True` was used instead of `primary_key=True` for a `mapped_column` definition. This PR corrects the typo to resolve the deployment issue.

---
<a href="https://cursor.com/background-agent?bcId=bc-66354ffc-7b85-4550-b182-3ee9f972bc73">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-66354ffc-7b85-4550-b182-3ee9f972bc73">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

