### PR TITLE
Fix snooze notification medication deletion bug

### DIFF
--- a/main.py
+++ b/main.py
@@ -348,7 +348,7 @@ class MedicineReminderBot:
                 await update.message.reply_text("אנא התחילו עם /start")
                 return
 
-            medicines = await DatabaseManager.get_user_medicines(db_user.id)
+            medicines = await DatabaseManager.get_user_medicines(db_user.id, active_only=False)
 
             if not medicines:
                 message = f"""
@@ -974,7 +974,7 @@ class MedicineReminderBot:
             # Back to medicines list
             if data == "medicines_list" or data == "medicine_manage" or data.startswith("medicines_page_"):
                 db_user = await DatabaseManager.get_user_by_telegram_id(user.id)
-                medicines = await DatabaseManager.get_user_medicines(db_user.id) if db_user else []
+                medicines = await DatabaseManager.get_user_medicines(db_user.id, active_only=False) if db_user else []
                 offset = 0
                 if data.startswith("medicines_page_"):
                     try:

--- a/utils/keyboards.py
+++ b/utils/keyboards.py
@@ -216,7 +216,7 @@ def get_medicines_keyboard(medicines: List, offset: int = 0) -> InlineKeyboardMa
 
 def get_medicine_detail_keyboard(medicine_id: int, is_active: bool = True) -> InlineKeyboardMarkup:
     """Keyboard for individual medicine details with a toggle for notifications"""
-    toggle_label = "ביטול התראות" if is_active else "חדש התראות"
+    toggle_label = "🔕 השהה התראה" if is_active else "🔔 חדש התראות"
     keyboard = [
         [
             InlineKeyboardButton(f"{config.EMOJIS['clock']} שנה שעות", callback_data=f"medicine_schedule_{medicine_id}"),


### PR DESCRIPTION
Display snoozed (inactive) medicines in "My medications" list.

Snoozing notifications was incorrectly causing medicines to disappear from the "My medications" list because the query for user medicines was filtering for active ones only. This PR updates `get_user_medicines` calls to include inactive medicines.

---
<a href="https://cursor.com/background-agent?bcId=bc-8633b72e-fa82-4361-9d0b-b368ae337c9f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8633b72e-fa82-4361-9d0b-b368ae337c9f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

