### PR TITLE
Find better emoji for paused medications

### DIFF
--- a/config.py
+++ b/config.py
@@ -150,6 +150,7 @@ class Config:
         "symptoms": "🤒",
         "clock": "🕒",
         "home": "🏠",
+        "paused": "⏸️",
     }
 
     # Backward-compat alias for occasional typos

--- a/main.py
+++ b/main.py
@@ -359,7 +359,7 @@ class MedicineReminderBot:
             else:
                 message = f"{config.EMOJIS['medicine']} <b>התרופות שלכם:</b>\n\n"
                 for medicine in medicines:
-                    status_emoji = config.EMOJIS["success"] if medicine.is_active else config.EMOJIS["error"]
+                    status_emoji = config.EMOJIS["success"] if medicine.is_active else config.EMOJIS["paused"]
                     inventory_warning = ""
 
                     if medicine.inventory_count <= medicine.low_stock_threshold:
@@ -994,7 +994,7 @@ class MedicineReminderBot:
                     slice_start = max(0, offset)
                     slice_end = slice_start + config.MAX_MEDICINES_PER_PAGE
                     for medicine in medicines[slice_start:slice_end]:
-                        status_emoji = config.EMOJIS["success"] if medicine.is_active else config.EMOJIS["error"]
+                        status_emoji = config.EMOJIS["success"] if medicine.is_active else config.EMOJIS["paused"]
                         inventory_warning = ""
                         if medicine.inventory_count <= medicine.low_stock_threshold:
                             inventory_warning = f" {config.EMOJIS['warning']}"

--- a/utils/keyboards.py
+++ b/utils/keyboards.py
@@ -173,7 +173,7 @@ def get_medicines_keyboard(medicines: List, offset: int = 0) -> InlineKeyboardMa
     slice_end = slice_start + page_size
     page_items = medicines[slice_start:slice_end]
     for i, medicine in enumerate(page_items):
-        status_emoji = config.EMOJIS["success"] if medicine.is_active else config.EMOJIS["error"]
+        status_emoji = config.EMOJIS["success"] if medicine.is_active else config.EMOJIS["paused"]
         # Removed warning emoji from button label for clarity
 
         button_text = f"{status_emoji} {medicine.name}"


### PR DESCRIPTION
Replace the red 'X' emoji with a neutral pause emoji for paused medications.

---
<a href="https://cursor.com/background-agent?bcId=bc-87a03b8b-7bcd-4121-bd0f-ca267a1832a9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-87a03b8b-7bcd-4121-bd0f-ca267a1832a9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

